### PR TITLE
Fix vite config syntax

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,5 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
-  base: "/slabikyx/"
-  }
-)
+  base: "/slabikyx/",
+})


### PR DESCRIPTION
## Summary
- close the config object in `vite.config.ts` with `}`
- add a trailing comma to prevent syntax errors

## Testing
- `npm run build` *(fails: `vue-tsc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a0a03e088327bad444c255f1367f